### PR TITLE
Base ID of Heapbox on ID of selectbox it's replacing

### DIFF
--- a/src/jquery.heapbox-0.9.3.js
+++ b/src/jquery.heapbox-0.9.3.js
@@ -54,7 +54,7 @@ HeapBox 0.9.3
 	createInstance: function() {
 
          return {
-	          heapId: Math.round(Math.random() * 99999999),
+	          heapId: $(this.element).attr('id') || Math.round(Math.random() * 99999999),
 		      state: false
 		 };		 
 	 },


### PR DESCRIPTION
The random ID generated was pretty pointless for styling purposes. It makes more sense to base the ID on a prefixed version of the original select's ID.
