### PR TITLE
inheritVisibility, mousewheel, onChange update and `no-refresh`

### DIFF
--- a/src/jquery.heapbox-0.9.3.js
+++ b/src/jquery.heapbox-0.9.3.js
@@ -55,7 +55,7 @@ HeapBox 0.9.3
 	createInstance: function() {
 
          return {
-	          heapId: Math.round(Math.random() * 99999999),
+	          heapId: $(this.element).attr('id') || Math.round(Math.random() * 99999999),
 		      state: false
 		 };		 
 	 },
@@ -419,7 +419,8 @@ HeapBox 0.9.3
 		var _data = jQuery.parseJSON(data);
 		var selected = false;
 
-		if(this.isSourceElementSelect) this._refreshSourceSelectbox(_data);
+		// No need to refresh the Select box
+		// if(this.isSourceElementSelect) this._refreshSourceSelectbox(_data);
 
 		heapBoxheapOptionsEl = $('<ul/>', {  
 			'class': 'heapOptions'
@@ -537,15 +538,15 @@ HeapBox 0.9.3
     _optionsToJson: function(){
 
     	var options = [];
-
+    	
     	$(this.element).find("option").each(function(){
    
     		options.push({
-    			'value': $(this).attr("value"),
-    			'text': $(this).text(),
-    			'icon': $(this).attr("data-icon-src"),
-    			'disabled': $(this).attr("disabled"),
-    			'selected': $(this).is(":selected") ? "selected":''
+    			'value'		: $(this).attr("value"),
+    			'text'		: $(this).text(),
+    			'icon'		: $(this).attr("data-icon-src"),
+    			'disabled'	: $(this).attr("disabled"),
+    			'selected'	: $(this).is(":selected") ? "selected":''
     		});
 
     	});
@@ -624,6 +625,7 @@ HeapBox 0.9.3
 		$(this.element).find("option").remove();
 
 		$.each(data,function(){
+			
 			option = $('<option/>',{  
               value: this.value,
 			  text: this.text,


### PR DESCRIPTION
- new option: inheritVisibility

`inheritVisibility` will set the initial state of the heatbox to
`hidden` incase the original <select> element is hidden as well.
- mousewheel support
- onChange gets source element in addition to `rel`
- Removed `refreshSourceSelectbox` execution
- added ChezFre's pull #9 which creates a unique ID for the, it's a must!
